### PR TITLE
fix: move dependencies out of project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,17 +20,19 @@ classifiers = [
     "Topic :: Communications :: Chat",
 ]
 
-[project.urls]
-Homepage = "https://github.com/alvis233/nanobot-channel-weixin"
-Repository = "https://github.com/alvis233/nanobot-channel-weixin"
-Issues = "https://github.com/alvis233/nanobot-channel-weixin/issues"
-
 dependencies = [
     "nanobot-ai",
     "httpx>=0.28.0",
     "cryptography>=44.0.0",
     "qrcode>=8.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/alvis233/nanobot-channel-weixin"
+Repository = "https://github.com/alvis233/nanobot-channel-weixin"
+Issues = "https://github.com/alvis233/nanobot-channel-weixin/issues"
+
+
 
 [project.entry-points."nanobot.channels"]
 weixin = "nanobot_channel_weixin:WeixinChannel"


### PR DESCRIPTION
Resolves #1

### What changed
Moved the `dependencies` list out of the `[project.urls]` table and placed it correctly under the `[project]` section.

### Why it changed
The `dependencies` list was accidentally placed inside `[project.urls]`. Build tools expect all values under `urls` to be string URLs, which caused a build error when it encountered a list of package names. This fix aligns the configuration with PEP 621 standards, ensuring the project and its dependencies can be installed correctly.