### PR TITLE
fix: token management and CDN media upload/download

### DIFF
--- a/nanobot_channel_weixin/api.py
+++ b/nanobot_channel_weixin/api.py
@@ -6,6 +6,7 @@ import hashlib
 import secrets
 from base64 import b64encode
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from loguru import logger
@@ -86,11 +87,24 @@ async def get_updates(
     """Long-poll POST getupdates → {ret, msgs[], get_updates_buf}."""
     url = f"{_trailing(base_url)}ilink/bot/getupdates"
     body = {"get_updates_buf": get_updates_buf, "base_info": {}}
+    logger.debug(
+        "getUpdates: url={} token={}... buf_len={}",
+        url, token[:12] if token else "NONE", len(get_updates_buf),
+    )
     try:
         async with httpx.AsyncClient(timeout=timeout_s + 5) as c:
             r = await c.post(url, json=body, headers=_build_headers(token), timeout=timeout_s + 5)
             r.raise_for_status()
-            return r.json()
+            data = r.json()
+            ret = data.get("ret", 0)
+            errcode = data.get("errcode", 0)
+            msgs = data.get("msgs", [])
+            buf_len = len(data.get("get_updates_buf", ""))
+            logger.debug(
+                "getUpdates: ret={} errcode={} msgs={} buf_len={} errmsg={}",
+                ret, errcode, len(msgs), buf_len, data.get("errmsg", ""),
+            )
+            return data
     except httpx.ReadTimeout:
         logger.debug("getUpdates: client-side timeout, returning empty")
         return {"ret": 0, "msgs": [], "get_updates_buf": get_updates_buf}
@@ -133,30 +147,36 @@ async def send_media_message(
     media_item: dict[str, Any],
     text: str = "",
 ) -> str:
-    """Send a media message (image/video/file). Returns client_id."""
+    """Send a media message (image/video/file).
+
+    Matches upstream protocol: each item is sent as a separate API call.
+    If text is provided, it is sent first, then the media item.
+    """
     url = f"{_trailing(base_url)}ilink/bot/sendmessage"
     items: list[dict[str, Any]] = []
     if text:
         items.append({"type": 1, "text_item": {"text": text}})
     items.append(media_item)
 
-    cid = f"nanobot-{secrets.token_hex(8)}"
-    body = {
-        "msg": {
-            "from_user_id": "",
-            "to_user_id": to_user_id,
-            "client_id": cid,
-            "message_type": 2,
-            "message_state": 2,
-            "item_list": items,
-            "context_token": context_token,
-        },
-        "base_info": {},
-    }
-    async with httpx.AsyncClient(timeout=API_TIMEOUT_S) as c:
-        r = await c.post(url, json=body, headers=_build_headers(token))
-        r.raise_for_status()
-    return cid
+    last_cid = ""
+    for item in items:
+        last_cid = f"nanobot-{secrets.token_hex(8)}"
+        body = {
+            "msg": {
+                "from_user_id": "",
+                "to_user_id": to_user_id,
+                "client_id": last_cid,
+                "message_type": 2,
+                "message_state": 2,
+                "item_list": [item],
+                "context_token": context_token,
+            },
+            "base_info": {},
+        }
+        async with httpx.AsyncClient(timeout=API_TIMEOUT_S) as c:
+            r = await c.post(url, json=body, headers=_build_headers(token))
+            r.raise_for_status()
+    return last_cid
 
 
 # ── CDN helpers ──────────────────────────────────────────────────────────
@@ -170,14 +190,14 @@ async def download_cdn_media(
     """Download and AES-128-ECB decrypt a CDN file."""
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-    url = f"{cdn_base_url}?{encrypt_query_param}"
+    url = f"{cdn_base_url}/download?encrypted_query_param={quote(encrypt_query_param)}"
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as c:
         r = await c.get(url)
         r.raise_for_status()
         ciphertext = r.content
 
-    cipher = Cipher(algorithms.AES(bytes.fromhex(aes_key_hex)), modes.ECB())
-    plaintext = cipher.decryptor().update(ciphertext) + cipher.decryptor().finalize()
+    decryptor = Cipher(algorithms.AES(bytes.fromhex(aes_key_hex)), modes.ECB()).decryptor()
+    plaintext = decryptor.update(ciphertext) + decryptor.finalize()
 
     # PKCS7 unpad
     pad = plaintext[-1]
@@ -197,7 +217,8 @@ async def upload_cdn_file(
     """Encrypt + upload a local file to CDN. Returns metadata for building a media message."""
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-    raw_data = open(file_path, "rb").read()
+    with open(file_path, "rb") as f:
+        raw_data = f.read()
     rawsize = len(raw_data)
     raw_md5 = hashlib.md5(raw_data).hexdigest()
     aes_key = secrets.token_bytes(16)
@@ -205,8 +226,8 @@ async def upload_cdn_file(
     # PKCS7 pad + AES-128-ECB encrypt
     pad_len = 16 - (rawsize % 16)
     padded = raw_data + bytes([pad_len] * pad_len)
-    cipher = Cipher(algorithms.AES(aes_key), modes.ECB())
-    ciphertext = cipher.encryptor().update(padded) + cipher.encryptor().finalize()
+    encryptor = Cipher(algorithms.AES(aes_key), modes.ECB()).encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
 
     filekey = f"nanobot_{secrets.token_hex(8)}"
 
@@ -232,16 +253,22 @@ async def upload_cdn_file(
     if not upload_param:
         raise RuntimeError("getuploadurl returned empty upload_param")
 
-    # PUT ciphertext to CDN
-    cdn_url = f"{cdn_base_url}?{upload_param}"
+    cdn_url = f"{cdn_base_url}/upload?encrypted_query_param={quote(upload_param)}&filekey={quote(filekey)}"
     async with httpx.AsyncClient(timeout=60) as c:
-        r = await c.put(cdn_url, content=ciphertext, headers={"Content-Type": "application/octet-stream"})
-        r.raise_for_status()
+        r = await c.post(cdn_url, content=ciphertext, headers={"Content-Type": "application/octet-stream"})
+        if r.status_code >= 400:
+            err_msg = r.headers.get("x-error-message", r.text[:200])
+            raise RuntimeError(f"CDN upload failed {r.status_code}: {err_msg}")
+
+    download_param = r.headers.get("x-encrypted-param", "")
+    if not download_param:
+        raise RuntimeError("CDN response missing x-encrypted-param header")
 
     return {
         "filekey": filekey,
         "aeskey": aes_key.hex(),
-        "download_param": upload_param,
+        "download_param": download_param,
         "filesize_cipher": len(ciphertext),
         "filesize_raw": rawsize,
     }
+

--- a/nanobot_channel_weixin/auth.py
+++ b/nanobot_channel_weixin/auth.py
@@ -61,10 +61,19 @@ def list_account_ids() -> list[str]:
 
 
 def _register_account_id(account_id: str) -> None:
-    ids = list_account_ids()
-    if account_id not in ids:
-        ids.append(account_id)
-        _index_path().write_text(json.dumps(ids, indent=2))
+    old_ids = list_account_ids()
+    # Remove stale account files from previous logins
+    for old_id in old_ids:
+        if old_id != account_id:
+            old_file = _account_path(old_id)
+            if old_file.exists():
+                old_file.unlink()
+                logger.debug("Removed stale account file: {}", old_id)
+            old_buf = _sync_dir() / f"{old_id}.buf"
+            if old_buf.exists():
+                old_buf.unlink()
+    # Only keep the current account
+    _index_path().write_text(json.dumps([account_id], indent=2))
 
 
 # ── Account data ─────────────────────────────────────────────────────────
@@ -121,15 +130,20 @@ def save_account(account_id: str, token: str, base_url: str, user_id: str = "") 
     except OSError:
         pass
     _register_account_id(account_id)
+    # Clear stale sync buf so new session starts fresh
+    buf_path = _sync_dir() / f"{account_id}.buf"
+    if buf_path.exists():
+        buf_path.unlink()
+        logger.info("Cleared stale sync buf for {}", account_id)
 
 
 def get_default_account() -> AccountData | None:
-    """Return the first configured account, or None."""
-    for aid in list_account_ids():
-        acct = load_account(aid)
-        if acct and acct.configured:
-            return acct
-    return None
+    """Return the current account (only one is kept after each login)."""
+    ids = list_account_ids()
+    if not ids:
+        return None
+    acct = load_account(ids[0])
+    return acct if acct and acct.configured else None
 
 
 # ── Sync buf persistence ─────────────────────────────────────────────────
@@ -201,8 +215,11 @@ async def login_with_qr(
                 return None
 
             aid = normalize_account_id(bot_id)
+            logger.info(
+                "WeChat login OK: bot_id={} account_id={} base_url={} token={}... user_id={}",
+                bot_id, aid, srv_url, bot_token[:12] if bot_token else "NONE", user_id,
+            )
             save_account(aid, bot_token, srv_url, user_id)
-            logger.info("WeChat login OK: account_id={}", aid)
             return load_account(aid)
 
         await asyncio.sleep(1)

--- a/nanobot_channel_weixin/channel.py
+++ b/nanobot_channel_weixin/channel.py
@@ -19,7 +19,9 @@ from nanobot_channel_weixin.api import (
     DEFAULT_BASE_URL,
     download_cdn_media,
     get_updates,
+    send_media_message,
     send_message,
+    upload_cdn_file,
 )
 from nanobot_channel_weixin.auth import (
     AccountData,
@@ -67,7 +69,12 @@ def _strip_markdown(text: str) -> str:
 
 
 def _media_dir() -> str:
-    """Resolve the weixin media directory (works with or without nanobot config)."""
+    """Resolve the weixin media directory.
+
+    Uses nanobot's configured media path (~/.nanobot/media/weixin/) when running
+    inside the gateway. Falls back to /tmp/nanobot/media/weixin/ when nanobot
+    config is unavailable (e.g. standalone CLI testing).
+    """
     try:
         from nanobot.config.paths import get_media_dir
         return str(get_media_dir("weixin"))
@@ -131,13 +138,9 @@ class WeixinChannel(BaseChannel):
         logger.info("WeChat channel stopped")
 
     async def send(self, msg: OutboundMessage) -> None:
-        """Send a reply back through WeChat."""
+        """Send a reply back through WeChat (text and/or media)."""
         if not self._account or not self._account.configured:
             logger.warning("WeChat: cannot send, account not configured")
-            return
-
-        text = _strip_markdown(msg.content.strip())
-        if not text:
             return
 
         to = msg.chat_id
@@ -146,22 +149,94 @@ class WeixinChannel(BaseChannel):
             logger.warning("WeChat: no context_token for {}, cannot reply", to)
             return
 
-        try:
-            await send_message(
-                base_url=self._account.base_url,
-                token=self._account.token,
-                to_user_id=to,
-                text=text,
-                context_token=ctx_token,
-            )
-            logger.debug("WeChat: sent to {}", to)
-        except Exception as e:
-            logger.error("WeChat: send failed to {}: {}", to, e)
+        text = _strip_markdown(msg.content.strip()) if msg.content else ""
+
+        # Send media files if present
+        if msg.media:
+            for file_path in msg.media:
+                try:
+                    await self._send_media_file(file_path, to, ctx_token, text)
+                    text = ""  # caption only on the first media
+                except Exception as e:
+                    logger.error("WeChat: media send failed {}: {}", file_path, e)
+
+        # Send remaining text (or standalone text if no media)
+        if text:
+            try:
+                await send_message(
+                    base_url=self._account.base_url,
+                    token=self._account.token,
+                    to_user_id=to,
+                    text=text,
+                    context_token=ctx_token,
+                )
+                logger.debug("WeChat: text sent to {}", to)
+            except Exception as e:
+                logger.error("WeChat: send failed to {}: {}", to, e)
+
+    async def _send_media_file(
+        self, file_path: str, to: str, ctx_token: str, caption: str
+    ) -> None:
+        """Upload a local file to CDN and send as a media message."""
+        import mimetypes
+        from base64 import b64encode as _b64
+
+        mime, _ = mimetypes.guess_type(file_path)
+        mime = mime or "application/octet-stream"
+
+        if mime.startswith("image/"):
+            media_type = 1  # IMAGE
+        elif mime.startswith("video/"):
+            media_type = 2  # VIDEO
+        else:
+            media_type = 3  # FILE
+
+        cdn_base = (
+            self._cfg.get("cdnBaseUrl", CDN_BASE_URL) if self._cfg else CDN_BASE_URL
+        )
+        uploaded = await upload_cdn_file(
+            base_url=self._account.base_url,
+            token=self._account.token,
+            cdn_base_url=cdn_base,
+            file_path=file_path,
+            to_user_id=to,
+            media_type=media_type,
+        )
+
+        # aes_key in message: base64 of the hex string (matches upstream protocol)
+        aes_key_b64 = _b64(uploaded["aeskey"].encode()).decode()
+        media_ref = {
+            "encrypt_query_param": uploaded["download_param"],
+            "aes_key": aes_key_b64,
+            "encrypt_type": 1,
+        }
+
+        if media_type == 1:
+            item = {"type": 2, "image_item": {"media": media_ref, "mid_size": uploaded["filesize_cipher"]}}
+        elif media_type == 2:
+            item = {"type": 5, "video_item": {"media": media_ref, "video_size": uploaded["filesize_cipher"]}}
+        else:
+            fname = os.path.basename(file_path)
+            item = {"type": 4, "file_item": {"media": media_ref, "file_name": fname, "len": str(uploaded["filesize_raw"])}}
+
+        await send_media_message(
+            base_url=self._account.base_url,
+            token=self._account.token,
+            to_user_id=to,
+            context_token=ctx_token,
+            media_item=item,
+            text=caption,
+        )
+        logger.info("WeChat: media sent to {} type={} file={}", to, mime, file_path)
 
     # ── long-poll loop ───────────────────────────────────────────────────
 
     async def _poll_loop(self, account: AccountData) -> None:
         buf = load_sync_buf(account.account_id)
+        logger.info(
+            "WeChat: poll_loop starting, has_sync_buf={}",
+            bool(buf),
+        )
         failures = 0
 
         while self._running:
@@ -176,15 +251,40 @@ class WeixinChannel(BaseChannel):
                 errcode = resp.get("errcode", 0)
 
                 if ret != 0 or errcode != 0:
+                    errmsg = resp.get("errmsg", "")
                     if errcode == _SESSION_EXPIRED or ret == _SESSION_EXPIRED:
-                        logger.error("WeChat: session expired, pausing {}s", _SESSION_PAUSE_S)
+                        # Try clearing stale sync_buf first
+                        if buf:
+                            logger.warning("WeChat: session expired, clearing sync_buf and retrying...")
+                            buf = ""
+                            save_sync_buf(account.account_id, "")
+                            await asyncio.sleep(1)
+                            continue
+
+                        # Try reloading account from disk (user may have re-logged in)
+                        refreshed = get_default_account()
+                        if refreshed and refreshed.configured and refreshed.token != account.token:
+                            logger.info(
+                                "WeChat: detected new token on disk ({}...), hot-reloading",
+                                refreshed.token[:12],
+                            )
+                            account = refreshed
+                            self._account = refreshed
+                            buf = ""
+                            continue
+
+                        logger.error(
+                            "WeChat: session expired (ret={} errcode={} errmsg={}), "
+                            "pausing {}s. Re-login: nanobot-weixin login",
+                            ret, errcode, errmsg, _SESSION_PAUSE_S,
+                        )
                         await self._sleep(_SESSION_PAUSE_S)
                         failures = 0
                         continue
                     failures += 1
                     logger.warning(
-                        "WeChat: getUpdates error ret={} errcode={} ({}/{})",
-                        ret, errcode, failures, _MAX_FAILURES,
+                        "WeChat: getUpdates error ret={} errcode={} errmsg={} ({}/{})",
+                        ret, errcode, errmsg, failures, _MAX_FAILURES,
                     )
                     if failures >= _MAX_FAILURES:
                         failures = 0


### PR DESCRIPTION
## Login Session

- Fix stale token loaded on gateway restart: each QR login generates a new account_id, but `get_default_account()` returned the oldest entry. Now only the most recent account is kept, and stale credential files are cleaned up.

- Hot-reload token on session expiry: when the poll loop receives errcode -14, it checks disk for a newer token (from a re-login in another terminal) before pausing.

## Media(Sorry, previously only tested text transmission)

- Fix CDN download URL: add missing `/download` path and `encrypted_query_param` query key (was causing 404 on inbound image download). fixes #3 

- Fix CDN upload: change HTTP method from PUT to POST, read the actual download parameter from the `x-encrypted-param` response header instead of reusing the upload parameter.

- Fix media message delivery: send each message item as a separate API call (text first, then media), matching the upstream protocol. Previously items were bundled into one request which caused images to be silently dropped.