### PR TITLE
fix: use nanobot config paths instead of hardcoded ~/.nanobot

### DIFF
--- a/nanobot_channel_weixin/auth.py
+++ b/nanobot_channel_weixin/auth.py
@@ -20,7 +20,11 @@ _LOGIN_TIMEOUT_S = 480
 
 
 def _state_dir() -> Path:
-    d = Path.home() / ".nanobot" / "state" / "weixin"
+    try:
+        from nanobot.config.paths import get_runtime_subdir
+        d = get_runtime_subdir("state") / "weixin"
+    except Exception:
+        d = Path.home() / ".nanobot" / "state" / "weixin"
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/nanobot_channel_weixin/cli.py
+++ b/nanobot_channel_weixin/cli.py
@@ -11,9 +11,18 @@ from nanobot_channel_weixin.api import DEFAULT_BASE_URL
 from nanobot_channel_weixin.auth import get_default_account, list_account_ids, load_account, login_with_qr
 
 
+def _resolve_config_path() -> Path:
+    """Return the nanobot config path, respecting multi-instance setup."""
+    try:
+        from nanobot.config.loader import get_config_path
+        return get_config_path()
+    except Exception:
+        return Path.home() / ".nanobot" / "config.json"
+
+
 def _load_base_url() -> str:
     """Read baseUrl from nanobot config if available."""
-    cfg_path = Path.home() / ".nanobot" / "config.json"
+    cfg_path = _resolve_config_path()
     if cfg_path.exists():
         try:
             cfg = json.loads(cfg_path.read_text())
@@ -25,7 +34,7 @@ def _load_base_url() -> str:
 
 def _enable_in_config() -> None:
     """Auto-set channels.weixin.enabled = true in config.json."""
-    cfg_path = Path.home() / ".nanobot" / "config.json"
+    cfg_path = _resolve_config_path()
     if not cfg_path.exists():
         return
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nanobot-channel-weixin"
 version = "0.1.0"
 description = "Personal WeChat channel plugin for nanobot (via iLink Bot API)"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.11"
 readme = "README.md"
 authors = [
@@ -12,7 +12,6 @@ keywords = ["nanobot", "wechat", "weixin", "chatbot", "channel-plugin"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

- **auth.py**: `_state_dir()` now uses `get_runtime_subdir("state")` from `nanobot.config.paths` to resolve the state directory, with graceful fallback to `~/.nanobot/state/weixin/` for standalone CLI use.
- **cli.py**: Extracted `_resolve_config_path()` helper that uses `get_config_path()` from `nanobot.config.loader`. Both `_load_base_url()` and `_enable_in_config()` now use this helper to respect multi-instance setups.
- **pyproject.toml**: Migrated `license` from deprecated table format `{text = "MIT"}` to SPDX string `"MIT"`, and removed the redundant `License :: OSI Approved :: MIT License` classifier (fixes setuptools deprecation warnings).

## Motivation

Previously, all runtime paths (account credentials, sync buffers, config file) were hardcoded to `~/.nanobot/...`. When nanobot runs with a custom config path (multi-instance), the weixin plugin would still read/write to the default location, causing state isolation issues.

## Test plan

- [ ] Verify `nanobot-weixin login` still works with default config (`~/.nanobot/config.json`)
- [ ] Verify `nanobot-weixin status` reads accounts from the correct state directory
- [ ] Verify `uv build` produces a clean wheel with no deprecation warnings

Made with [Cursor](https://cursor.com)