### PR TITLE
feat: multi-account WeChat support, stability fixes, and community pl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Personal WeChat (微信) channel plugin for [nanobot](https://github.com/HKUDS/n
 - **CN**: 支持多账号登录、账号间对话隔离以及基于用户 ID 匹配的重登录迁移。同时，修复了因微信官方变动导致的图片上传与下载失败问题。插件已更名为 `weixin-community`，以避免与官方原生 `weixin` 插件产生命名冲突。
 
 > [!NOTE]
-> **EN**: While multiple WeChat accounts can be bound, `nanobot` currently uses a shared history file for memory. As a result, conversation isolation across multiple accounts may be imperfect when the LLM reads historical context.
-> **CN**: 尽管支持绑定多个微信账号，但由于 `nanobot` 目前使用公共历史文件记录对话，大语言模型在读取历史背景时可能无法实现完美的账号间隔离。
+> **EN**: While multiple WeChat accounts can be bound, `nanobot` currently uses a shared history file for memory. As a result, conversation isolation across multiple accounts may be imperfect when the LLM reads historical context. Additionally, image downloads may intermittently return 500 errors; this appears to be a server-side instability beyond the plugin's control.
+> **CN**: 尽管支持绑定多个微信账号，但由于 `nanobot` 目前使用公共历史文件记录对话，大语言模型在读取背景时可能无法实现完美的账号间隔离。此外，由于服务器端可能存在处理延迟或不稳定性，图片下载有时会随机出现 500 错误，这并非插件本身的问题。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,42 +8,34 @@ Personal WeChat (微信) channel plugin for [nanobot](https://github.com/HKUDS/n
 
 ---
 
+## Latest Updates / 最新动态
+
+- **EN**: Supporting multiple accounts, per-account conversation isolation, and user ID matched re-login migration. We've also resolved image upload/download issues caused by changes on the official WeChat side. The plugin has been renamed to `weixin-community` to prevent any naming conflicts with the official `weixin` plugin.
+- **CN**: 支持多账号登录、账号间对话隔离以及基于用户 ID 匹配的重登录迁移。同时，修复了因微信官方变动导致的图片上传与下载失败问题。插件已更名为 `weixin-community`，以避免与官方原生 `weixin` 插件产生命名冲突。
+
+> [!NOTE]
+> **EN**: While multiple WeChat accounts can be bound, `nanobot` currently uses a shared history file for memory. As a result, conversation isolation across multiple accounts may be imperfect when the LLM reads historical context.
+> **CN**: 尽管支持绑定多个微信账号，但由于 `nanobot` 目前使用公共历史文件记录对话，大语言模型在读取历史背景时可能无法实现完美的账号间隔离。
+
+---
+
 ## Important Notice / 重要通知
 
-**EN:**🎉 **Great news!** The official `nanobot` framework now natively supports the personal WeChat channel. You can directly use the built-in feature, and **this plugin is no longer required!**
+**EN:** 🎉 **Good news!** The official `nanobot` framework now natively supports the personal WeChat channel. Our community version has been renamed to `weixin-community` to coexist perfectly with the official one. You can choose to use either or both!
 
-As an early community exploration and my very first open-source learning project, it has successfully fulfilled its "historical mission"!
+I will continue to maintain and update this plugin in my spare time. This repository remains a permanent part of the `nanobot` ecosystem, serving as a reference for plugin development.
 
-I may still tinker with this and make small updates out of personal interest when I have free time. More importantly, **this repository will remain open permanently**. If you happen to be interested in developing `nanobot` plugins, I hope the source code here can serve as a solid reference and provide you with some inspiration and help!
+**CN:** 🎉 **好消息！** `nanobot` 官方现已原生支持个人微信 Channel。为了完美兼容，本项目已更名为 `weixin-community`，可以与官方版本共存。你可以根据需要选择使用，或者两者并用！
 
-
-**CN:**🎉 **好消息！** `nanobot` 官方现已原生支持个人微信 Channel，大家可以直接使用框架自带的原生功能，**无需再额外安装此插件啦！**
-
-本项目作为早期的社区探索方案，以及我的首个开源学习项目，也算是圆满完成了它的“历史使命”！
-
-未来在业余时间充裕的情况下，我可能还会出于兴趣做一些小更新。更重要的是，**这个仓库将永久保留**。如果你恰好对开发 `nanobot` 插件感兴趣，希望这里的源码能作为一个不错的参考案例，为你提供一些灵感和帮助！
-
-### Uninstallation / 卸载说明
-
-If you have installed this plugin previously, it is highly recommended to uninstall it to avoid any conflicts with the official native features: 
-
-```
-uv pip uninstall nanobot-channel-weixin --python ~/.local/share/uv/tools/nanobot-ai/bin/python
-```
-
-or
-
-```
-pip uninstall nanobot-channel-weixin
-```
+我依然会在业余时间持续维护和更新本插件。这个仓库将永久保留，作为 `nanobot` 插件开发的一个参考案例，欢迎大家交流学习。
 
 ---
 
 ## Disclaimer / 免责声明
 
-**EN:** This plugin is a Python re-implementation based on protocol analysis of the official npm package [`@tencent-weixin/openclaw-weixin`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin). It communicates with the same [iLink Bot API](https://ilinkai.weixin.qq.com) backend but is built entirely from scratch for the nanobot ecosystem — no original source code was copied. This project is for educational, research, and personal use only. It is not affiliated with or endorsed by Tencent or WeChat.
+**EN:** This plugin is a Python implementation based on official documentation and the public npm package [`@tencent-weixin/openclaw-weixin`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin). It communicates with the [iLink Bot API](https://ilinkai.weixin.qq.com) and is built from scratch for the nanobot ecosystem. This project is for educational, research, and personal use only. It is not affiliated with or endorsed by Tencent or WeChat.
 
-**CN:** 本插件基于对官方 npm 包 [`@tencent-weixin/openclaw-weixin`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin) 的协议分析，使用 Python 从零重新实现。它使用相同的 [iLink Bot API](https://ilinkai.weixin.qq.com) 后端，但完全为 nanobot 生态独立编写，未复制任何原始源码。本项目仅供学习、研究和个人使用，与腾讯或微信官方无关，亦未获其背书。
+**CN:** 本插件参考官方文档及公开的 npm 包 [`@tencent-weixin/openclaw-weixin`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin) 进行了 Python 适配开发。它通过 [iLink Bot API](https://ilinkai.weixin.qq.com) 进行通信，完全为 nanobot 生态独立编写。本项目仅供学习、研究和个人使用，与腾讯或微信官方无关，亦未获其背书。
 
 ---
 
@@ -104,7 +96,7 @@ nanobot plugins list
 You should see: / 你应该看到：
 
 ```
-│ WeChat   │ plugin  │ no      │
+│ WeChat (Community)  │ plugin  │ no      │
 ```
 
 ### 2. Login with QR code / 扫码登录
@@ -117,9 +109,9 @@ You should see: / 你应该看到：
 nanobot-weixin login
 ```
 
-Scan the QR code with your WeChat app to bind your account. Credentials are saved to `~/.nanobot/state/weixin/`.
+Scan the QR code with your WeChat app to bind your account. Credentials are saved to `~/.nanobot/state/weixin-community/`.
 
-用微信扫描终端中的二维码完成绑定，凭证自动保存到 `~/.nanobot/state/weixin/`。
+用微信扫描终端中的二维码完成绑定，凭证自动保存到 `~/.nanobot/state/weixin-community/`。
 
 ### 3. Configure / 配置
 
@@ -130,7 +122,7 @@ The login command auto-enables the channel in `~/.nanobot/config.json`. You can 
 ```json
 {
   "channels": {
-    "weixin": {
+    "weixin-community": {
       "enabled": true,
       "allowFrom": ["*"]
     }
@@ -149,6 +141,30 @@ Now send a message to your WeChat bot — nanobot will reply!
 现在通过微信给机器人发消息，nanobot 就会回复！
 
 <img src="example.jpg" alt="Chat Demo" width="400">
+
+---
+
+## Multiple Accounts / 多账户
+
+Each `nanobot-weixin login` adds a new account entry. All accounts run concurrently.
+
+每次执行 `nanobot-weixin login` 都会添加一个新的账号条目，所有账号并行运行。
+
+```bash
+nanobot-weixin login     # scan with WeChat account A
+nanobot-weixin login     # scan with WeChat account B
+nanobot-weixin status    # show all configured accounts
+```
+
+Each (account + peer user) pair has its own isolated AI conversation context — accounts never interfere with each other.
+
+每个「微信账号 + 发消息用户」组合拥有独立的 AI 对话上下文，账号之间不会串台。
+
+To remove an account: / 移除一个账户：
+
+```bash
+nanobot-weixin remove <account_id>
+```
 
 ---
 

--- a/nanobot_channel_weixin/api.py
+++ b/nanobot_channel_weixin/api.py
@@ -18,6 +18,12 @@ LONG_POLL_TIMEOUT_S = 35
 API_TIMEOUT_S = 15
 CONFIG_TIMEOUT_S = 10
 
+CHANNEL_VERSION = "2.1.1"
+ILINK_APP_ID = "bot"
+# iLink-App-ClientVersion: uint32 encoded as 0x00MMNNPP from semver
+_ver = tuple(int(x) for x in CHANNEL_VERSION.split("."))
+ILINK_APP_CLIENT_VERSION = str((_ver[0] << 16) | (_ver[1] << 8) | _ver[2])
+
 
 def _random_wechat_uin() -> str:
     """X-WECHAT-UIN header: random uint32 → decimal → base64."""
@@ -30,10 +36,16 @@ def _build_headers(token: str | None = None) -> dict[str, str]:
         "Content-Type": "application/json",
         "AuthorizationType": "ilink_bot_token",
         "X-WECHAT-UIN": _random_wechat_uin(),
+        "iLink-App-Id": ILINK_APP_ID,
+        "iLink-App-ClientVersion": ILINK_APP_CLIENT_VERSION,
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
+
+
+def _build_base_info() -> dict[str, str]:
+    return {"channel_version": CHANNEL_VERSION}
 
 
 def _trailing(url: str) -> str:
@@ -87,7 +99,7 @@ async def get_updates(
 ) -> dict[str, Any]:
     """Long-poll POST getupdates → {ret, msgs[], get_updates_buf}."""
     url = f"{_trailing(base_url)}ilink/bot/getupdates"
-    body = {"get_updates_buf": get_updates_buf, "base_info": {}}
+    body = {"get_updates_buf": get_updates_buf, "base_info": _build_base_info()}
     logger.debug(
         "getUpdates: url={} token={}... buf_len={}",
         url, token[:12] if token else "NONE", len(get_updates_buf),
@@ -132,7 +144,7 @@ async def send_message(
             "item_list": [{"type": 1, "text_item": {"text": text}}],
             "context_token": context_token,
         },
-        "base_info": {},
+        "base_info": _build_base_info(),
     }
     async with httpx.AsyncClient(timeout=API_TIMEOUT_S) as c:
         r = await c.post(url, json=body, headers=_build_headers(token))
@@ -172,7 +184,7 @@ async def send_media_message(
                 "item_list": [item],
                 "context_token": context_token,
             },
-            "base_info": {},
+            "base_info": _build_base_info(),
         }
         async with httpx.AsyncClient(timeout=API_TIMEOUT_S) as c:
             r = await c.post(url, json=body, headers=_build_headers(token))
@@ -197,7 +209,7 @@ async def get_config(
     body = {
         "ilink_user_id": ilink_user_id,
         "context_token": context_token,
-        "base_info": {},
+        "base_info": _build_base_info(),
     }
     async with httpx.AsyncClient(timeout=CONFIG_TIMEOUT_S) as c:
         r = await c.post(url, json=body, headers=_build_headers(token))
@@ -218,7 +230,7 @@ async def send_typing(
         "ilink_user_id": ilink_user_id,
         "typing_ticket": typing_ticket,
         "status": status,
-        "base_info": {},
+        "base_info": _build_base_info(),
     }
     async with httpx.AsyncClient(timeout=CONFIG_TIMEOUT_S) as c:
         r = await c.post(url, json=body, headers=_build_headers(token))
@@ -228,19 +240,66 @@ async def send_typing(
 # ── CDN helpers ──────────────────────────────────────────────────────────
 
 
+def _build_cdn_download_url(cdn_base_url: str, encrypt_query_param: str) -> str:
+    """Construct CDN download URL with properly URL-encoded query param."""
+    return f"{cdn_base_url}/download?encrypted_query_param={quote(encrypt_query_param, safe='')}"
+
+
+async def _fetch_cdn_bytes(
+    cdn_base_url: str,
+    encrypt_query_param: str,
+    full_url: str | None = None,
+) -> bytes:
+    """Download raw bytes from CDN, trying full_url first then constructed URL as fallback."""
+    constructed_url = _build_cdn_download_url(cdn_base_url, encrypt_query_param) if encrypt_query_param else ""
+
+    # Try full_url first (server-returned), fall back to constructed URL.
+    urls: list[str] = []
+    if full_url:
+        urls.append(full_url)
+    if constructed_url and constructed_url != full_url:
+        urls.append(constructed_url)
+    if not urls:
+        raise RuntimeError("CDN download: no URL available (neither full_url nor encrypt_query_param)")
+
+    last_err: Exception | None = None
+    for url in urls:
+        try:
+            logger.debug("CDN download: trying url={}", url[:120])
+            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as c:
+                r = await c.get(url, headers={
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+                })
+                if not r.is_success:
+                    body_preview = r.text[:200] if r.content else ""
+                    logger.warning(
+                        "CDN download: HTTP {} for url={} body={}",
+                        r.status_code, url[:120], body_preview,
+                    )
+                    r.raise_for_status()
+                return r.content
+        except Exception as e:
+            last_err = e
+            logger.debug("CDN download: failed url={} err={}", url[:120], e)
+            if len(urls) > 1:
+                continue
+    raise last_err or RuntimeError("CDN download: all URLs failed")
+
+
 async def download_cdn_media(
     cdn_base_url: str,
     encrypt_query_param: str,
     aes_key_hex: str,
+    full_url: str | None = None,
 ) -> bytes:
-    """Download and AES-128-ECB decrypt a CDN file."""
+    """Download and AES-128-ECB decrypt a CDN file.
+
+    Tries *full_url* first (server-returned complete download URL), falls back
+    to constructing the URL from *encrypt_query_param* + *cdn_base_url*.
+    """
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-    url = f"{cdn_base_url}/download?encrypted_query_param={quote(encrypt_query_param)}"
-    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as c:
-        r = await c.get(url)
-        r.raise_for_status()
-        ciphertext = r.content
+    ciphertext = await _fetch_cdn_bytes(cdn_base_url, encrypt_query_param, full_url)
 
     decryptor = Cipher(algorithms.AES(bytes.fromhex(aes_key_hex)), modes.ECB()).decryptor()
     plaintext = decryptor.update(ciphertext) + decryptor.finalize()
@@ -250,6 +309,15 @@ async def download_cdn_media(
     if 1 <= pad <= 16 and all(b == pad for b in plaintext[-pad:]):
         plaintext = plaintext[:-pad]
     return plaintext
+
+
+async def download_cdn_media_plain(
+    cdn_base_url: str,
+    encrypt_query_param: str,
+    full_url: str | None = None,
+) -> bytes:
+    """Download raw bytes from CDN without decryption (for unencrypted media)."""
+    return await _fetch_cdn_bytes(cdn_base_url, encrypt_query_param, full_url)
 
 
 async def upload_cdn_file(
@@ -288,27 +356,53 @@ async def upload_cdn_file(
         "filesize": len(ciphertext),
         "aeskey": aes_key.hex(),
         "no_need_thumb": True,
-        "base_info": {},
+        "base_info": _build_base_info(),
     }
     async with httpx.AsyncClient(timeout=API_TIMEOUT_S) as c:
         r = await c.post(upload_url, json=upload_body, headers=_build_headers(token))
         r.raise_for_status()
         upload_resp = r.json()
 
-    upload_param = upload_resp.get("upload_param", "")
-    if not upload_param:
-        raise RuntimeError("getuploadurl returned empty upload_param")
+    upload_full_url = (upload_resp.get("upload_full_url") or "").strip()
+    upload_param = upload_resp.get("upload_param") or ""
+    if not upload_full_url and not upload_param:
+        raise RuntimeError(
+            f"getuploadurl returned no upload URL (need upload_full_url or upload_param), "
+            f"resp={upload_resp}"
+        )
 
-    cdn_url = f"{cdn_base_url}/upload?encrypted_query_param={quote(upload_param)}&filekey={quote(filekey)}"
-    async with httpx.AsyncClient(timeout=60) as c:
-        r = await c.post(cdn_url, content=ciphertext, headers={"Content-Type": "application/octet-stream"})
-        if r.status_code >= 400:
-            err_msg = r.headers.get("x-error-message", r.text[:200])
-            raise RuntimeError(f"CDN upload failed {r.status_code}: {err_msg}")
+    if upload_full_url:
+        cdn_url = upload_full_url
+    else:
+        cdn_url = f"{cdn_base_url}/upload?encrypted_query_param={quote(upload_param)}&filekey={quote(filekey)}"
 
-    download_param = r.headers.get("x-encrypted-param", "")
+    download_param = ""
+    max_retries = 3
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            async with httpx.AsyncClient(timeout=60) as c:
+                r = await c.post(cdn_url, content=ciphertext, headers={"Content-Type": "application/octet-stream"})
+                if 400 <= r.status_code < 500:
+                    err_msg = r.headers.get("x-error-message", r.text[:200])
+                    raise RuntimeError(f"CDN upload client error {r.status_code}: {err_msg}")
+                if r.status_code != 200:
+                    err_msg = r.headers.get("x-error-message", f"status {r.status_code}")
+                    raise RuntimeError(f"CDN upload server error: {err_msg}")
+                download_param = r.headers.get("x-encrypted-param", "")
+                if not download_param:
+                    raise RuntimeError("CDN response missing x-encrypted-param header")
+                break
+        except RuntimeError as e:
+            last_error = e
+            if "client error" in str(e):
+                raise
+            if attempt < max_retries:
+                logger.warning("CDN upload attempt {}/{} failed, retrying: {}", attempt, max_retries, e)
+            else:
+                logger.error("CDN upload all {} attempts failed: {}", max_retries, e)
     if not download_param:
-        raise RuntimeError("CDN response missing x-encrypted-param header")
+        raise last_error or RuntimeError(f"CDN upload failed after {max_retries} attempts")
 
     return {
         "filekey": filekey,

--- a/nanobot_channel_weixin/auth.py
+++ b/nanobot_channel_weixin/auth.py
@@ -20,7 +20,11 @@ _LOGIN_TIMEOUT_S = 480
 
 
 def _state_dir() -> Path:
-    d = Path.home() / ".nanobot" / "state" / "weixin"
+    try:
+        from nanobot.config.paths import get_runtime_subdir
+        d = get_runtime_subdir("state") / "weixin-community"
+    except Exception:
+        d = Path.home() / ".nanobot" / "state" / "weixin-community"
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -61,19 +65,11 @@ def list_account_ids() -> list[str]:
 
 
 def _register_account_id(account_id: str) -> None:
-    old_ids = list_account_ids()
-    # Remove stale account files from previous logins
-    for old_id in old_ids:
-        if old_id != account_id:
-            old_file = _account_path(old_id)
-            if old_file.exists():
-                old_file.unlink()
-                logger.debug("Removed stale account file: {}", old_id)
-            old_buf = _sync_dir() / f"{old_id}.buf"
-            if old_buf.exists():
-                old_buf.unlink()
-    # Only keep the current account
-    _index_path().write_text(json.dumps([account_id], indent=2))
+    ids = list_account_ids()
+    if account_id in ids:
+        return
+    ids.append(account_id)
+    _index_path().write_text(json.dumps(ids, indent=2))
 
 
 # ── Account data ─────────────────────────────────────────────────────────
@@ -120,6 +116,17 @@ def load_account(account_id: str) -> AccountData | None:
 
 
 def save_account(account_id: str, token: str, base_url: str, user_id: str = "") -> None:
+    # If the same WeChat user re-logged and got a new bot_id,
+    # clean up stale entries that share the same user_id.
+    if user_id:
+        for old_id in list_account_ids():
+            if old_id == account_id:
+                continue
+            old_acct = load_account(old_id)
+            if old_acct and old_acct.user_id == user_id:
+                remove_account(old_id)
+                logger.info("Replaced stale account {} (same user_id={})", old_id, user_id)
+
     p = _account_path(account_id)
     data: dict[str, str] = {"token": token, "baseUrl": base_url}
     if user_id:
@@ -130,7 +137,6 @@ def save_account(account_id: str, token: str, base_url: str, user_id: str = "") 
     except OSError:
         pass
     _register_account_id(account_id)
-    # Clear stale sync buf so new session starts fresh
     buf_path = _sync_dir() / f"{account_id}.buf"
     if buf_path.exists():
         buf_path.unlink()
@@ -138,12 +144,40 @@ def save_account(account_id: str, token: str, base_url: str, user_id: str = "") 
 
 
 def get_default_account() -> AccountData | None:
-    """Return the current account (only one is kept after each login)."""
+    """Return the first configured account."""
     ids = list_account_ids()
     if not ids:
         return None
     acct = load_account(ids[0])
     return acct if acct and acct.configured else None
+
+
+def load_all_accounts() -> list[AccountData]:
+    """Return all configured accounts."""
+    result: list[AccountData] = []
+    for aid in list_account_ids():
+        acct = load_account(aid)
+        if acct and acct.configured:
+            result.append(acct)
+    return result
+
+
+def remove_account(account_id: str) -> bool:
+    """Remove an account and its sync buf. Returns True if found."""
+    p = _account_path(account_id)
+    removed = False
+    if p.exists():
+        p.unlink()
+        removed = True
+    buf = _sync_dir() / f"{account_id}.buf"
+    if buf.exists():
+        buf.unlink()
+    ids = list_account_ids()
+    if account_id in ids:
+        ids.remove(account_id)
+        _index_path().write_text(json.dumps(ids, indent=2))
+        removed = True
+    return removed
 
 
 # ── Sync buf persistence ─────────────────────────────────────────────────

--- a/nanobot_channel_weixin/channel.py
+++ b/nanobot_channel_weixin/channel.py
@@ -21,6 +21,7 @@ from nanobot_channel_weixin.api import (
     TYPING_STATUS_CANCEL,
     TYPING_STATUS_TYPING,
     download_cdn_media,
+    download_cdn_media_plain,
     get_config,
     get_updates,
     send_media_message,
@@ -30,8 +31,10 @@ from nanobot_channel_weixin.api import (
 )
 from nanobot_channel_weixin.auth import (
     AccountData,
-    get_default_account,
+    load_account,
+    load_all_accounts,
     load_sync_buf,
+    remove_account,
     save_sync_buf,
 )
 
@@ -58,6 +61,7 @@ _BACKOFF_S = 30
 _RETRY_S = 2
 _SESSION_PAUSE_S = 300
 _TYPING_KEEPALIVE_S = 5
+_ACCOUNT_SCAN_INTERVAL_S = 10
 _CONFIG_CACHE_TTL_S = 24 * 3600
 
 
@@ -76,18 +80,18 @@ def _strip_markdown(text: str) -> str:
 
 
 def _media_dir() -> str:
-    """Resolve the weixin media directory.
+    """Resolve the weixin-community media directory.
 
-    Uses nanobot's configured media path (~/.nanobot/media/weixin/) when running
-    inside the gateway. Falls back to /tmp/nanobot/media/weixin/ when nanobot
+    Uses nanobot's configured media path (~/.nanobot/media/weixin-community/) when running
+    inside the gateway. Falls back to /tmp/nanobot/media/weixin-community/ when nanobot
     config is unavailable (e.g. standalone CLI testing).
     """
     try:
         from nanobot.config.paths import get_media_dir
-        return str(get_media_dir("weixin"))
+        return str(get_media_dir("weixin-community"))
     except Exception:
         import tempfile
-        d = os.path.join(tempfile.gettempdir(), "nanobot", "media", "weixin")
+        d = os.path.join(tempfile.gettempdir(), "nanobot", "media", "weixin-community")
         os.makedirs(d, exist_ok=True)
         return d
 
@@ -97,11 +101,11 @@ class WeixinChannel(BaseChannel):
     Personal WeChat channel.
 
     Login:   nanobot-weixin login
-    Config:  channels.weixin.enabled = true  in ~/.nanobot/config.json
+    Config:  channels.weixin-community.enabled = true  in ~/.nanobot/config.json
     """
 
-    name = "weixin"
-    display_name = "WeChat"
+    name = "weixin-community"
+    display_name = "WeChat (Community)"
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:
@@ -119,76 +123,140 @@ class WeixinChannel(BaseChannel):
             cfg = config or _DictConfig({})
         super().__init__(cfg, bus)
         self._cfg = config if isinstance(config, dict) else {}
-        self._context_tokens: dict[str, str] = {}
-        self._account: AccountData | None = None
-        # typing_ticket cache: {user_id: (ticket, fetched_at)}
-        self._typing_tickets: dict[str, tuple[str, float]] = {}
-        # active keepalive tasks: {user_id: asyncio.Task}
-        self._typing_tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+        self._accounts: dict[str, AccountData] = {}
+        # All per-session state uses (account_id, user_id) composite keys
+        # so multiple accounts never interfere with each other.
+        self._context_tokens: dict[tuple[str, str], str] = {}
+        self._typing_tickets: dict[tuple[str, str], tuple[str, float]] = {}
+        self._typing_tasks: dict[tuple[str, str], asyncio.Task] = {}  # type: ignore[type-arg]
 
     async def start(self) -> None:
-        """Start the long-poll monitor (blocks forever)."""
-        self._account = get_default_account()
-        if not self._account or not self._account.configured:
+        """Start long-poll monitors for all configured accounts.
+
+        Also starts a background watcher that detects accounts added
+        after the gateway is already running (e.g. via ``nanobot-weixin login``).
+        """
+        self._running = True
+        self._poll_tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+
+        for acct in load_all_accounts():
+            self._start_poll(acct)
+
+        if not self._accounts:
             logger.error(
                 "WeChat: no configured account. Run: nanobot-weixin login"
             )
-            return
 
-        self._running = True
+        watcher = asyncio.create_task(self._account_watcher())
+        try:
+            while self._running:
+                # Keep alive; individual poll_loops run as tracked tasks
+                await self._sleep(1)
+        finally:
+            watcher.cancel()
+            for t in self._poll_tasks.values():
+                t.cancel()
+
+    def _start_poll(self, acct: AccountData) -> None:
+        """Register an account and launch its poll_loop task."""
+        self._accounts[acct.account_id] = acct
+        self._poll_tasks[acct.account_id] = asyncio.create_task(
+            self._poll_loop(acct)
+        )
         logger.info(
             "WeChat channel starting: account={} base_url={}",
-            self._account.account_id,
-            self._account.base_url,
+            acct.account_id, acct.base_url,
         )
 
-        await self._poll_loop(self._account)
+    async def _account_watcher(self) -> None:
+        """Periodically scan disk for newly added accounts and start polling them."""
+        while self._running:
+            await self._sleep(_ACCOUNT_SCAN_INTERVAL_S)
+            try:
+                for acct in load_all_accounts():
+                    if acct.account_id not in self._accounts:
+                        logger.info(
+                            "WeChat: detected new account on disk, starting poll: {}",
+                            acct.account_id,
+                        )
+                        self._start_poll(acct)
+            except Exception as e:
+                logger.debug("WeChat: account watcher scan error: {}", e)
 
     async def stop(self) -> None:
         self._running = False
         logger.info("WeChat channel stopped")
 
+    def _resolve_send_target(
+        self, msg: OutboundMessage,
+    ) -> tuple[AccountData, str] | None:
+        """Extract the account and real peer user_id from an outbound message.
+
+        chat_id format is "owner:peer" where owner is account.user_id
+        (stable WeChat identity).  We also check metadata["account_id"]
+        for a direct account_id match.
+        """
+        chat_id = msg.chat_id
+        if ":" in chat_id:
+            owner, peer = chat_id.split(":", 1)
+        else:
+            owner = ""
+            peer = chat_id
+
+        # Try metadata account_id first (always exact)
+        acct_id = msg.metadata.get("account_id", "")
+        if acct_id and acct_id in self._accounts:
+            return self._accounts[acct_id], peer
+
+        # Match by owner (account.user_id)
+        if owner:
+            for acct in self._accounts.values():
+                if acct.user_id == owner or acct.account_id == owner:
+                    return acct, peer
+
+        if len(self._accounts) == 1:
+            return next(iter(self._accounts.values())), peer
+        return None
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a reply back through WeChat (text and/or media)."""
-        if not self._account or not self._account.configured:
-            logger.warning("WeChat: cannot send, account not configured")
+        result = self._resolve_send_target(msg)
+        if not result:
+            logger.warning("WeChat: cannot send, no matching account for msg")
             return
 
-        to = msg.chat_id
+        account, to = result
+        key = (account.account_id, to)
 
         if msg.metadata.get("_progress"):
-            # Progress messages mean the agent is still working. Don't forward
-            # them to WeChat, but (re)start typing if it was previously stopped.
-            task = self._typing_tasks.get(to)
+            task = self._typing_tasks.get(key)
             if not task or task.done():
-                ticket = self._typing_tickets.get(to, ("", 0))[0]
+                ticket = self._typing_tickets.get(key, ("", 0))[0]
                 if ticket:
-                    self._start_typing(to, ticket)
+                    self._start_typing(key, account, ticket)
             return
 
-        self._stop_typing(to)
-        ctx_token = self._context_tokens.get(to)
+        self._stop_typing(key, account)
+        ctx_token = self._context_tokens.get(key)
         if not ctx_token:
-            logger.warning("WeChat: no context_token for {}, cannot reply", to)
+            logger.warning("WeChat: no context_token for {}, cannot reply", key)
             return
 
         text = _strip_markdown(msg.content.strip()) if msg.content else ""
 
-        # Send media files if present
         if msg.media:
             for file_path in msg.media:
                 try:
-                    await self._send_media_file(file_path, to, ctx_token, text)
-                    text = ""  # caption only on the first media
+                    await self._send_media_file(account, file_path, to, ctx_token, text)
+                    text = ""
                 except Exception as e:
                     logger.error("WeChat: media send failed {}: {}", file_path, e)
 
-        # Send remaining text (or standalone text if no media)
         if text:
             try:
                 await send_message(
-                    base_url=self._account.base_url,
-                    token=self._account.token,
+                    base_url=account.base_url,
+                    token=account.token,
                     to_user_id=to,
                     text=text,
                     context_token=ctx_token,
@@ -198,7 +266,7 @@ class WeixinChannel(BaseChannel):
                 logger.error("WeChat: send failed to {}: {}", to, e)
 
     async def _send_media_file(
-        self, file_path: str, to: str, ctx_token: str, caption: str
+        self, account: AccountData, file_path: str, to: str, ctx_token: str, caption: str
     ) -> None:
         """Upload a local file to CDN and send as a media message."""
         import mimetypes
@@ -218,15 +286,14 @@ class WeixinChannel(BaseChannel):
             self._cfg.get("cdnBaseUrl", CDN_BASE_URL) if self._cfg else CDN_BASE_URL
         )
         uploaded = await upload_cdn_file(
-            base_url=self._account.base_url,
-            token=self._account.token,
+            base_url=account.base_url,
+            token=account.token,
             cdn_base_url=cdn_base,
             file_path=file_path,
             to_user_id=to,
             media_type=media_type,
         )
 
-        # aes_key in message: base64 of the hex string (matches upstream protocol)
         aes_key_b64 = _b64(uploaded["aeskey"].encode()).decode()
         media_ref = {
             "encrypt_query_param": uploaded["download_param"],
@@ -243,8 +310,8 @@ class WeixinChannel(BaseChannel):
             item = {"type": 4, "file_item": {"media": media_ref, "file_name": fname, "len": str(uploaded["filesize_raw"])}}
 
         await send_media_message(
-            base_url=self._account.base_url,
-            token=self._account.token,
+            base_url=account.base_url,
+            token=account.token,
             to_user_id=to,
             context_token=ctx_token,
             media_item=item,
@@ -254,45 +321,48 @@ class WeixinChannel(BaseChannel):
 
     # ── typing indicator ──────────────────────────────────────────────────
 
-    async def _get_typing_ticket(self, user_id: str, context_token: str) -> str:
+    async def _get_typing_ticket(
+        self, key: tuple[str, str], account: AccountData, context_token: str,
+    ) -> str:
         """Return a cached typing_ticket, refreshing from getconfig when stale."""
-        cached = self._typing_tickets.get(user_id)
+        cached = self._typing_tickets.get(key)
         if cached:
             ticket, fetched_at = cached
             if time.monotonic() - fetched_at < _CONFIG_CACHE_TTL_S:
                 return ticket
 
-        if not self._account or not self._account.configured:
-            return ""
+        user_id = key[1]
         try:
             resp = await get_config(
-                base_url=self._account.base_url,
-                token=self._account.token,
+                base_url=account.base_url,
+                token=account.token,
                 ilink_user_id=user_id,
                 context_token=context_token,
             )
             if resp.get("ret", 0) == 0:
                 ticket = resp.get("typing_ticket", "")
-                self._typing_tickets[user_id] = (ticket, time.monotonic())
-                logger.debug("WeChat: typing_ticket cached for {}", user_id)
+                self._typing_tickets[key] = (ticket, time.monotonic())
+                logger.debug("WeChat: typing_ticket cached for {}", key)
                 return ticket
         except Exception as e:
-            logger.debug("WeChat: getconfig failed for {}: {}", user_id, e)
-        return self._typing_tickets.get(user_id, ("", 0))[0]
+            logger.debug("WeChat: getconfig failed for {}: {}", key, e)
+        return self._typing_tickets.get(key, ("", 0))[0]
 
-    async def _typing_keepalive(self, user_id: str, ticket: str) -> None:
+    async def _typing_keepalive(
+        self, account: AccountData, user_id: str, ticket: str,
+    ) -> None:
         """Send TYPING immediately then repeat every _TYPING_KEEPALIVE_S until cancelled."""
-        if not self._account or not ticket:
+        if not ticket:
             return
         try:
             await send_typing(
-                self._account.base_url, self._account.token,
+                account.base_url, account.token,
                 user_id, ticket, TYPING_STATUS_TYPING,
             )
             while True:
                 await asyncio.sleep(_TYPING_KEEPALIVE_S)
                 await send_typing(
-                    self._account.base_url, self._account.token,
+                    account.base_url, account.token,
                     user_id, ticket, TYPING_STATUS_TYPING,
                 )
         except asyncio.CancelledError:
@@ -300,35 +370,38 @@ class WeixinChannel(BaseChannel):
         except Exception as e:
             logger.debug("WeChat: typing keepalive error for {}: {}", user_id, e)
 
-    def _start_typing(self, user_id: str, ticket: str) -> None:
-        """Start the typing indicator for a user (cancels any previous one)."""
-        self._stop_typing_silent(user_id)
+    def _start_typing(
+        self, key: tuple[str, str], account: AccountData, ticket: str,
+    ) -> None:
+        """Start the typing indicator (cancels any previous one for same key)."""
+        self._stop_typing_silent(key)
         if ticket:
-            self._typing_tasks[user_id] = asyncio.create_task(
-                self._typing_keepalive(user_id, ticket)
+            self._typing_tasks[key] = asyncio.create_task(
+                self._typing_keepalive(account, key[1], ticket)
             )
 
-    def _stop_typing_silent(self, user_id: str) -> bool:
+    def _stop_typing_silent(self, key: tuple[str, str]) -> bool:
         """Cancel the keepalive task without sending CANCEL. Returns True if was active."""
-        task = self._typing_tasks.pop(user_id, None)
+        task = self._typing_tasks.pop(key, None)
         if task and not task.done():
             task.cancel()
             return True
         return False
 
-    def _stop_typing(self, user_id: str) -> None:
+    def _stop_typing(self, key: tuple[str, str], account: AccountData) -> None:
         """Cancel the keepalive task and send CANCEL to the server (only if was active)."""
-        if not self._stop_typing_silent(user_id):
+        if not self._stop_typing_silent(key):
             return
-        if self._account and self._account.configured:
-            ticket = self._typing_tickets.get(user_id, ("", 0))[0]
-            if ticket:
-                asyncio.create_task(self._send_typing_cancel(user_id, ticket))
+        ticket = self._typing_tickets.get(key, ("", 0))[0]
+        if ticket:
+            asyncio.create_task(self._send_typing_cancel(account, key[1], ticket))
 
-    async def _send_typing_cancel(self, user_id: str, ticket: str) -> None:
+    async def _send_typing_cancel(
+        self, account: AccountData, user_id: str, ticket: str,
+    ) -> None:
         try:
             await send_typing(
-                self._account.base_url, self._account.token,
+                account.base_url, account.token,
                 user_id, ticket, TYPING_STATUS_CANCEL,
             )
         except Exception as e:
@@ -336,11 +409,38 @@ class WeixinChannel(BaseChannel):
 
     # ── long-poll loop ───────────────────────────────────────────────────
 
+    def _find_successor(
+        self, old_account_id: str, old_user_id: str,
+    ) -> AccountData | None:
+        """Find a successor account belonging to the same WeChat user.
+
+        When a WeChat re-login generates a new bot_id, the old poll_loop
+        needs to discover and adopt the new account.  We match by user_id
+        (the stable WeChat identity) to avoid cross-user misattribution.
+        """
+        if not old_user_id:
+            logger.warning(
+                "WeChat [{}]: no user_id on record, cannot search for successor",
+                old_account_id,
+            )
+            return None
+        candidates = load_all_accounts()
+        for acct in candidates:
+            if acct.account_id == old_account_id or acct.account_id in self._accounts:
+                continue
+            if acct.user_id == old_user_id:
+                return acct
+            logger.debug(
+                "WeChat [{}]: candidate [{}] skipped, user_id mismatch",
+                old_account_id, acct.account_id,
+            )
+        return None
+
     async def _poll_loop(self, account: AccountData) -> None:
         buf = load_sync_buf(account.account_id)
         logger.info(
-            "WeChat: poll_loop starting, has_sync_buf={}",
-            bool(buf),
+            "WeChat: poll_loop starting account={}, has_sync_buf={}",
+            account.account_id, bool(buf),
         )
         failures = 0
 
@@ -358,38 +458,57 @@ class WeixinChannel(BaseChannel):
                 if ret != 0 or errcode != 0:
                     errmsg = resp.get("errmsg", "")
                     if errcode == _SESSION_EXPIRED or ret == _SESSION_EXPIRED:
-                        # Try clearing stale sync_buf first
                         if buf:
-                            logger.warning("WeChat: session expired, clearing sync_buf and retrying...")
+                            logger.warning(
+                                "WeChat [{}]: session expired, clearing sync_buf and retrying...",
+                                account.account_id,
+                            )
                             buf = ""
                             save_sync_buf(account.account_id, "")
                             await asyncio.sleep(1)
                             continue
 
-                        # Try reloading account from disk (user may have re-logged in)
-                        refreshed = get_default_account()
+                        # Same account_id, new token (user re-logged same bot_id)
+                        refreshed = load_account(account.account_id)
                         if refreshed and refreshed.configured and refreshed.token != account.token:
                             logger.info(
-                                "WeChat: detected new token on disk ({}...), hot-reloading",
-                                refreshed.token[:12],
+                                "WeChat [{}]: detected new token on disk, hot-reloading",
+                                account.account_id,
                             )
                             account = refreshed
-                            self._account = refreshed
+                            self._accounts[account.account_id] = refreshed
+                            buf = ""
+                            continue
+
+                        # Different account_id: WeChat re-login often generates
+                        # a new bot_id.  Scan for any new accounts that appeared
+                        # on disk belonging to the same WeChat user.
+                        successor = self._find_successor(account.account_id, account.user_id)
+                        if successor:
+                            logger.info(
+                                "WeChat [{}]: migrating to successor account [{}], user_id={}",
+                                account.account_id, successor.account_id, account.user_id,
+                            )
+                            old_id = account.account_id
+                            self._accounts.pop(old_id, None)
+                            remove_account(old_id)
+                            account = successor
+                            self._accounts[successor.account_id] = successor
                             buf = ""
                             continue
 
                         logger.error(
-                            "WeChat: session expired (ret={} errcode={} errmsg={}), "
+                            "WeChat [{}]: session expired (ret={} errcode={} errmsg={}), "
                             "pausing {}s. Re-login: nanobot-weixin login",
-                            ret, errcode, errmsg, _SESSION_PAUSE_S,
+                            account.account_id, ret, errcode, errmsg, _SESSION_PAUSE_S,
                         )
                         await self._sleep(_SESSION_PAUSE_S)
                         failures = 0
                         continue
                     failures += 1
                     logger.warning(
-                        "WeChat: getUpdates error ret={} errcode={} errmsg={} ({}/{})",
-                        ret, errcode, errmsg, failures, _MAX_FAILURES,
+                        "WeChat [{}]: getUpdates error ret={} errcode={} errmsg={} ({}/{})",
+                        account.account_id, ret, errcode, errmsg, failures, _MAX_FAILURES,
                     )
                     if failures >= _MAX_FAILURES:
                         failures = 0
@@ -411,7 +530,10 @@ class WeixinChannel(BaseChannel):
                 break
             except Exception as e:
                 failures += 1
-                logger.error("WeChat: poll error ({}/{}): {}", failures, _MAX_FAILURES, e)
+                logger.error(
+                    "WeChat [{}]: poll error ({}/{}): {}",
+                    account.account_id, failures, _MAX_FAILURES, e,
+                )
                 if failures >= _MAX_FAILURES:
                     failures = 0
                     await self._sleep(_BACKOFF_S)
@@ -434,9 +556,10 @@ class WeixinChannel(BaseChannel):
         if msg.get("message_type", 0) != 1 or not from_user:
             return
 
+        key = (account.account_id, from_user)
         ctx_token = msg.get("context_token", "")
         if ctx_token:
-            self._context_tokens[from_user] = ctx_token
+            self._context_tokens[key] = ctx_token
 
         items = msg.get("item_list", [])
         parts: list[str] = []
@@ -490,12 +613,18 @@ class WeixinChannel(BaseChannel):
         if not content:
             return
 
-        ticket = await self._get_typing_ticket(from_user, ctx_token)
-        self._start_typing(from_user, ticket)
+        ticket = await self._get_typing_ticket(key, account, ctx_token)
+        self._start_typing(key, account, ticket)
+
+        # Use account.user_id (stable WeChat identity) instead of account_id
+        # (which changes on every re-login) so conversation history survives
+        # re-login while still isolating different WeChat accounts.
+        owner = account.user_id or account.account_id
+        chat_id = f"{owner}:{from_user}"
 
         await self._handle_message(
             sender_id=from_user,
-            chat_id=from_user,
+            chat_id=chat_id,
             content=content,
             media=media or None,
             metadata={
@@ -504,6 +633,51 @@ class WeixinChannel(BaseChannel):
                 "context_token": ctx_token,
             },
         )
+
+    def _parse_aes_key(self, info: dict[str, Any], kind: str) -> str | None:
+        """Parse AES key from media item, returning hex string or None.
+
+        Matches the official SDK's parseAesKey logic:
+        - For images: image_item.aeskey is a 32-char hex string → convert to
+          raw 16 bytes → use as AES key.
+        - For other types: media.aes_key is base64-encoded, decoding to either
+          16 raw bytes or 32-char hex string (which must be hex-decoded again).
+        - Returns the AES key as a 32-char hex string suitable for bytes.fromhex().
+        """
+        from base64 import b64decode, b64encode
+
+        ref = info.get("media", {})
+
+        # For images: prefer image_item.aeskey (raw hex) over media.aes_key.
+        # Convert hex aeskey → raw bytes → base64 for uniform handling.
+        raw_hex = info.get("aeskey", "")
+        if raw_hex:
+            aes_key_b64 = b64encode(bytes.fromhex(raw_hex)).decode()
+        else:
+            aes_key_b64 = ref.get("aes_key", "")
+
+        if not aes_key_b64:
+            return None
+
+        # parseAesKey: base64 → raw bytes.
+        # Two encodings in the wild:
+        #   - base64(raw 16 bytes)           → images
+        #   - base64(hex string of 16 bytes) → file / voice / video
+        decoded = b64decode(aes_key_b64)
+        if len(decoded) == 16:
+            return decoded.hex()
+        if len(decoded) == 32:
+            try:
+                hex_str = decoded.decode("ascii")
+                if all(c in "0123456789abcdefABCDEF" for c in hex_str):
+                    return bytes.fromhex(hex_str).hex()
+            except (UnicodeDecodeError, ValueError):
+                pass
+        logger.warning(
+            "WeChat: unexpected aes_key length after b64decode: {} bytes (kind={})",
+            len(decoded), kind,
+        )
+        return decoded.hex()
 
     async def _download_media(
         self,
@@ -515,21 +689,19 @@ class WeixinChannel(BaseChannel):
         """Download + AES decrypt a CDN media item. Returns local path."""
         ref = info.get("media", {})
         param = ref.get("encrypt_query_param", "")
-        aes_key = info.get("aeskey", "") or ref.get("aes_key", "")
+        full_url = ref.get("full_url", "")
 
-        if not param or not aes_key:
+        if not param and not full_url:
             return None
 
-        # aes_key can be 32-char hex or base64
-        if len(aes_key) == 32 and all(c in "0123456789abcdefABCDEF" for c in aes_key):
-            key_hex = aes_key
-        else:
-            from base64 import b64decode
-            key_hex = b64decode(aes_key).hex()
+        cdn = self._cfg.get("cdnBaseUrl", CDN_BASE_URL) if self._cfg else CDN_BASE_URL
 
         try:
-            cdn = self._cfg.get("cdnBaseUrl", CDN_BASE_URL) if self._cfg else CDN_BASE_URL
-            data = await download_cdn_media(cdn, param, key_hex)
+            key_hex = self._parse_aes_key(info, kind)
+            if key_hex:
+                data = await download_cdn_media(cdn, param, key_hex, full_url or None)
+            else:
+                data = await download_cdn_media_plain(cdn, param, full_url or None)
 
             out_dir = _media_dir()
             if not filename:

--- a/nanobot_channel_weixin/cli.py
+++ b/nanobot_channel_weixin/cli.py
@@ -8,7 +8,13 @@ import sys
 from pathlib import Path
 
 from nanobot_channel_weixin.api import DEFAULT_BASE_URL
-from nanobot_channel_weixin.auth import get_default_account, list_account_ids, load_account, login_with_qr
+from nanobot_channel_weixin.auth import (
+    get_default_account,
+    list_account_ids,
+    load_account,
+    login_with_qr,
+    remove_account,
+)
 
 
 def _load_base_url() -> str:
@@ -17,25 +23,25 @@ def _load_base_url() -> str:
     if cfg_path.exists():
         try:
             cfg = json.loads(cfg_path.read_text())
-            return cfg.get("channels", {}).get("weixin", {}).get("baseUrl", DEFAULT_BASE_URL)
+            return cfg.get("channels", {}).get("weixin-community", {}).get("baseUrl", DEFAULT_BASE_URL)
         except Exception:
             pass
     return DEFAULT_BASE_URL
 
 
 def _enable_in_config() -> None:
-    """Auto-set channels.weixin.enabled = true in config.json."""
+    """Auto-set channels.weixin-community.enabled = true in config.json."""
     cfg_path = Path.home() / ".nanobot" / "config.json"
     if not cfg_path.exists():
         return
     try:
         cfg = json.loads(cfg_path.read_text())
-        weixin = cfg.setdefault("channels", {}).setdefault("weixin", {})
+        weixin = cfg.setdefault("channels", {}).setdefault("weixin-community", {})
         if not weixin.get("enabled"):
             weixin["enabled"] = True
             weixin.setdefault("allowFrom", ["*"])
             cfg_path.write_text(json.dumps(cfg, indent=2, ensure_ascii=False))
-            print(f"  Auto-enabled weixin channel in {cfg_path}")
+            print(f"  Auto-enabled weixin-community channel in {cfg_path}")
     except Exception:
         pass
 
@@ -49,6 +55,9 @@ def cmd_login() -> None:
         account = await login_with_qr(base_url=base_url)
         if account:
             print(f"\n✅ WeChat connected!  account={account.account_id}")
+            total = len(list_account_ids())
+            if total > 1:
+                print(f"   ({total} accounts now configured)")
             _enable_in_config()
             print("\nStart the gateway to begin chatting:")
             print("  nanobot gateway")
@@ -73,13 +82,30 @@ def cmd_status() -> None:
         print(f"  {aid}: {status}{user}")
 
 
+def cmd_remove() -> None:
+    args = sys.argv[2:]
+    if not args:
+        print("Usage: nanobot-weixin remove <account_id>")
+        print("\nRun 'nanobot-weixin status' to see account IDs.")
+        return
+    aid = args[0]
+    if remove_account(aid):
+        print(f"✅ Removed account: {aid}")
+        remaining = len(list_account_ids())
+        print(f"   ({remaining} account(s) remaining)")
+    else:
+        print(f"❌ Account not found: {aid}")
+        sys.exit(1)
+
+
 def main() -> None:
     args = sys.argv[1:]
     if not args or args[0] in ("-h", "--help", "help"):
         print("Usage: nanobot-weixin <command>\n")
         print("Commands:")
-        print("  login    Scan QR code to connect your WeChat account")
-        print("  status   Show configured WeChat accounts")
+        print("  login              Scan QR code to add a WeChat account")
+        print("  status             Show configured WeChat accounts")
+        print("  remove <id>        Remove a WeChat account")
         return
 
     cmd = args[0]
@@ -87,6 +113,8 @@ def main() -> None:
         cmd_login()
     elif cmd == "status":
         cmd_status()
+    elif cmd == "remove":
+        cmd_remove()
     else:
         print(f"Unknown command: {cmd}")
         print("Run: nanobot-weixin --help")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nanobot-channel-weixin"
 version = "0.1.0"
 description = "Personal WeChat channel plugin for nanobot (via iLink Bot API)"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.11"
 readme = "README.md"
 authors = [
@@ -12,7 +12,6 @@ keywords = ["nanobot", "wechat", "weixin", "chatbot", "channel-plugin"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +34,7 @@ Issues = "https://github.com/alvis233/nanobot-channel-weixin/issues"
 
 
 [project.entry-points."nanobot.channels"]
-weixin = "nanobot_channel_weixin:WeixinChannel"
+weixin-community = "nanobot_channel_weixin:WeixinChannel"
 
 [project.scripts]
 nanobot-weixin = "nanobot_channel_weixin.cli:main"


### PR DESCRIPTION
## Key Changes
1. Multi-account Support
Users can now log in with multiple WeChat accounts using the login command. All configured accounts run concurrently within the same gateway instance. Conversation context is isolated per (account_id, peer_id) pair..<br/>
**IMPORTANT**
Conversation Isolation Note: While accounts are independent, nanobot's memory management relies on a shared HISTORY.md. This may lead to overlapping historical context if the LLM reads the global history file.

2. Media Handling Fixes
Adapted the image upload and download logic to match recent changes in the official WeChat (iLink Bot) protocol. Resolved CDN 500 errors and download failures.<br/>
**IMPORTANT**
Media Download Reliability: During testing, we observed that image downloads return HTTP 500 errors intermittently, **even for the same file**. This suggests a server-side instability or processing delay (ingestion lag) in the iLink Bot API that is beyond the plugin's control. We have updated the `README.md` to document this behavior and set appropriate expectations for users, as the issue persists regardless of retry or backoff strategies.

3. Stability & UX
Re-login Migration: Sessions that expire can be renewed while maintaining the same user_id mapping, ensuring conversation continuity.
Polling Logic: Fixed issues where newly added accounts wouldn't start polling immediately if the gateway was already running.

4. Branding & Compatibility
Renamed the channel internal ID and package metadata to weixin-community. This ensures zero conflict with the official nanobot built-in weixin channel, allowing both to be installed and used simultaneously.